### PR TITLE
Add OSS license + author information

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Simone Chiocchetti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # smesh
+
+[![Build Status](https://github.com/trixi-framework/smesh/workflows/CI/badge.svg)](https://github.com/trixi-framework/smesh/actions?query=workflow%3ACI)
+[![License: MIT](https://img.shields.io/badge/License-MIT-success.svg)](https://opensource.org/license/mit/)
+
 Simple mesh generation tools
 
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # smesh
 Simple mesh generation tools
+
+
+## Authors
+Smesh was initiated by
+[Simone Chiocchetti](https://www.mi.uni-koeln.de/NumSim/dr-simone-chiocchetti/)
+(University of Cologne, Germany), who is also its principal maintainer.
+
+
+## License and contributing
+Smesh is available under the MIT license (see [LICENSE.md](LICENSE.md)).
+Contributions by the community are very welcome!


### PR DESCRIPTION
I think it would be good to attach a license to this repo, such that other people know how this may be used. We should also (in a later PR) add Zenodo information such that we get a citable DOI for this repo.