### PR TITLE
Use defensive compiler arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,4 +33,13 @@ add_executable(smesh_run
 )
 target_link_libraries(smesh_run PRIVATE smesh smesh_io)
 
+
+# Set appropriate compile flags
+# Note: Require Fortran 2018 standard due to use of C interoperability funcionality
+target_compile_options(smesh PUBLIC "-fPIC")
+target_compile_options(smesh_io PUBLIC "-fPIC")
+target_compile_options(smesh PRIVATE -Wall -Wextra -Werror -std=f2018)
+target_compile_options(smesh_io PRIVATE -Wall -Wextra -Werror -std=f2018)
+target_compile_options(smesh_run PRIVATE -Wall -Wextra -Werror -std=f2018)
+
 install(TARGETS smesh smesh_io smesh_run)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(smesh_run PRIVATE smesh smesh_io)
 
 
 # Set appropriate compile flags
-# Note: Require Fortran 2018 standard due to use of C interoperability funcionality
+# Note: Require Fortran 2018 standard due to use of C interoperability functionality
 target_compile_options(smesh PUBLIC "-fPIC")
 target_compile_options(smesh_io PUBLIC "-fPIC")
 target_compile_options(smesh PRIVATE -Wall -Wextra -Werror -std=f2018)

--- a/src/smesh.f90
+++ b/src/smesh.f90
@@ -1356,7 +1356,7 @@ CONTAINS
         INTEGER, DIMENSION(:,:), ALLOCATABLE, INTENT(OUT)  :: edge_elements
         INTEGER, DIMENSION(:,:), ALLOCATABLE  :: edge_elements_temp
         INTEGER                                           :: nelem, i, n1, j1, i1, nedge, k
-        INTEGER, PARAMETER, DIMENSION(2,3) :: ed = reshape([2,3,3,1,1,2], [2,3]) ! mod(i+j, 3)
+        ! INTEGER, PARAMETER, DIMENSION(2,3) :: ed = reshape([2,3,3,1,1,2], [2,3]) ! mod(i+j, 3)
         INTEGER, DIMENSION(2) :: edge1, edge2
         nelem = size(veb, 2)
         ALLOCATE(edge_found_marker(size(ve)))


### PR DESCRIPTION
I suggest to add these build arguments to ensure that most annoying/bad habits in the code are already caught and prevented by the compiler.

Nice job in triggering only a single error @simonechiocchetti!